### PR TITLE
Change email to a mailto link

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ final List<String> filtered = new ArrayList<>();
 
 ## Application
 
-If you are interested in becoming a developer on the Avicus Network, do so by sending an email to [keenan@avicus.net](keenan@avicus.net) that addresses the following information (in any style you wish):
+If you are interested in becoming a developer on the Avicus Network, do so by sending an email to [keenan@avicus.net](mailto:keenan@avicus.net) that addresses the following information (in any style you wish):
 
 * Your full name, what you would like to be called (nickname?) and your age
 * Details about your experience with the following languages and technologies: Java, Ruby, Ruby on Rails, HTML/CSS, SQL Databases, Redis, continuous integration (Jenkins), bash/SSH, Git (or Subversion) and Maven


### PR DESCRIPTION
This commit allows the email to be pre-filled in the default client, using a `mailto` link.

Before: 
![img](https://i.imgur.com/Pf2xdBq.gif)

After: 
![img](https://i.imgur.com/uHZaozq.gif)
